### PR TITLE
Take extra margin into account when calculating absoluteBottom

### DIFF
--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -73,7 +73,12 @@ extension ViewController: UITableViewDelegate {
         guard heightDiff == 0 else { return }
 
         let absoluteTop: CGFloat = 0;
-        let absoluteBottom: CGFloat = scrollView.contentSize.height - scrollView.frame.size.height;
+        let absoluteBottom: CGFloat = (
+            collectionView.contentSize.height
+            - collectionView.frame.size.height
+            + collectionView.contentInset.bottom
+            + collectionView.layoutMargins.bottom
+        )
 
         let isScrollingDown = scrollDiff > 0 && scrollView.contentOffset.y > absoluteTop
         let isScrollingUp = scrollDiff < 0 && scrollView.contentOffset.y < absoluteBottom


### PR DESCRIPTION
Take layout margins and content inset into account when calculating `absoluteBottom`.

Without adding these adjustments back in, when scrolling up the animation will appear to start late, i.e. you need to scroll up a number of pixels equal to the height of the bottom margin and content inset before the header starts to uncollapse.

See details on #8. Fixes #8.